### PR TITLE
add wind's speed & direction for Openweather daily forecast

### DIFF
--- a/lib/src/main/java/com/survivingwithandroid/weather/lib/provider/openweathermap/OpenweathermapProvider.java
+++ b/lib/src/main/java/com/survivingwithandroid/weather/lib/provider/openweathermap/OpenweathermapProvider.java
@@ -199,6 +199,8 @@ public class OpenweathermapProvider implements IWeatherProvider {
                 // Clouds
                 df.weather.clouds.setPerc(jDayForecast.getInt("clouds"));
 
+                df.weather.wind.setSpeed(getFloat("speed", jDayForecast));
+                df.weather.wind.setDeg(getFloat("deg", jDayForecast));
 
                 // Rain (use opt to handle option parameters
                 JSONObject rObj = jObj.optJSONObject("rain");


### PR DESCRIPTION
wind's speed and directions was not included on the Openweather  daily forecast for parsing

http://api.openweathermap.org/data/2.5/forecast/daily?q=Taipei&mode=json&units=metric&cnt=7
