### PR TITLE
Adding toString() to print City objects

### DIFF
--- a/lib/src/main/java/com/survivingwithandroid/weather/lib/model/City.java
+++ b/lib/src/main/java/com/survivingwithandroid/weather/lib/model/City.java
@@ -107,6 +107,10 @@ public class City {
         this.region = region;
     }
 
+    public String toString(){
+        return this.name + ", " + this.country;
+    }
+
     public static class CityBuilder {
         /*
          * Unique city identfier


### PR DESCRIPTION
Adding the toString() will simplify displaying City objects. Take for example
when a ListView with an ArrayAdapter<City> is used to display city results.
The City's toString() method will be called to convert each item in the array
into a view. The toString() will streamline the process of displaying City results
in a view.
