### PR TITLE
Fix parsing time in Yahoo provider if default locale is not english

### DIFF
--- a/lib/src/main/java/com/survivingwithandroid/weather/lib/provider/yahooweather/YahooWeatherProvider.java
+++ b/lib/src/main/java/com/survivingwithandroid/weather/lib/provider/yahooweather/YahooWeatherProvider.java
@@ -43,6 +43,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.UnknownFormatConversionException;
 
 
@@ -193,7 +194,7 @@ public class YahooWeatherProvider implements IWeatherProvider {
                         currentTag = "update";
                     } else if (tagName.equals("yweather:astronomy")) {
                         String val = parser.getAttributeValue(null, "sunrise");
-                        SimpleDateFormat sdf = new SimpleDateFormat("h:mm a");
+                        SimpleDateFormat sdf = new SimpleDateFormat("h:mm a", Locale.ENGLISH);
                         if (val != null) {
                             java.util.Date d = sdf.parse(val);
                             weather.location.setSunrise(d.getTime());


### PR DESCRIPTION
There seems to be a bug in android which causes this problem. Try to run these 2 lines with the system language set to German:

SimpleDateFormat sdf = new SimpleDateFormat("h:mm a");
Date d = sdf.parse("7:18 am");

It will fail with ParseException because it doesn't recognize "am" because it expects "vorm". (Short for "Vormittag")

Since Yahoo only supports english anyway (and has no intent to change that https://developer.yahoo.com/forum/General-Discussion-at-YDN/Can-Yahoo-Weather-API-show-by/1275022713000-d78748d9-0247-313b-ad9e-3503b8ea3d07/) we can set the locale to English when parsing to avoid this issue.

As a side note: Samsung seems to have patched this android bug because its working fine on different kinds of Samsung tablets.

I reproduced this bug on Android 4.2.2, and 5.1.1.